### PR TITLE
Changes from SquallToast project

### DIFF
--- a/lms/M3StoreOps.scala
+++ b/lms/M3StoreOps.scala
@@ -42,13 +42,13 @@ trait M3StoreOpsExp extends BaseExp
                        with StoreExpOpt
                        with EqualExp 
                        with IfThenElseExp {
-
+  import ddbt.codegen.ScalaGen.STORE_WATCHED
   val USE_STORE1 = true // whether we specialize temporary maps in Store1
   val USE_UNIQUE_INDEX_WHEN_POSSIBLE = true
   val STORE_TYPE = "M3StoreOpsExp.STORE_TYPE"
   val NAME_ATTRIBUTE = "_name"
 
-  def named(name: String, tp: Type, mutable: Boolean = false) = 
+  def named(name: String, tp: Type, mutable: Boolean = false) =
     named(name, mutable)(man(tp))
 
   def named[T](name: String, mutable: Boolean = false)(implicit mT: Manifest[T]) = { 
@@ -85,7 +85,7 @@ trait M3StoreOpsExp extends BaseExp
     s.attributes.put(STORE_TYPE, storeType)
   }
 
-  def m3add[E <: Entry](map: Rep[Store[E]], ent: Rep[E])(implicit m: Manifest[E]) = {    
+  def m3add[E <: Entry](map: Rep[Store[E]], ent: Rep[E])(implicit m: Manifest[E]) = {
     val n = m.typeArguments.size
     val lastMan = m.typeArguments.last
     val entVal = ent.get(n)
@@ -141,7 +141,15 @@ trait M3StoreOpsExp extends BaseExp
               __ifThenElse(
                 __equal(currentEnt, unit(null)),
                 stUnsafeInsert(map, ent, idx), 
-                { currentEnt += (n, entVal)
+                {
+                  val watched = map.asInstanceOf[Sym[_]].attributes.get(STORE_WATCHED).asInstanceOf[Option[Boolean]].getOrElse(false)
+                  if (watched) {
+                    val oldEnt = steCopy(currentEnt)
+                    currentEnt += (n, entVal)
+                    steLogUpdate(map, oldEnt, currentEnt)
+                  } else {
+                    currentEnt += (n, entVal)
+                  }
                   val currentEntVal = currentEnt.get(n)
                   __ifThenElse(
                     __equal(currentEntVal, unit(zero(lastMan))),
@@ -300,7 +308,7 @@ trait ScalaGenM3StoreOps extends ScalaGenBase
 
   override def emitNode(sym: Sym[Any], rhs: Def[Any]) = rhs match {
     case Named(n) => /*emitValDef(sym, n);*/ sym.attributes.update(NAME_ATTRIBUTE, n)
-    case StUnsafeInsert(x, e, i) => 
+    case StUnsafeInsert(x, e, i) =>
       emitValDef(sym, quote(x) + ".unsafeInsert(" + i + "," + quote(e) + ")")
     case M3Add(s, e) =>
       stream.println(quote(s) + ".add(" + quote(e) + ")")

--- a/lms/oltp/opt/lifters/StoreLifter.scala
+++ b/lms/oltp/opt/lifters/StoreLifter.scala
@@ -83,12 +83,16 @@ trait SEntryExp extends StoreOps with BaseExp with EffectExp with VariablesExp {
   case class SteIncrease    [E <: Entry: Manifest](x: Exp[E], i: Int, v: Exp[Any]) extends Def[Unit]
   case class SteDecrease    [E <: Entry: Manifest](x: Exp[E], i: Int, v: Exp[Any]) extends Def[Unit]
   case class SteGet         [E <: Entry: Manifest](x: Exp[E], i: Int) extends Def[Any]
+  case class SteCopy        [E <: Entry: Manifest](x: Exp[E]) extends Def[E]
+  case class SteLogUpdate   [E <: Entry: Manifest](s: Exp[Store[E]], x: Exp[E], y: Exp[E]) extends Def[Unit]
 
   def steMakeMutable [E <: Entry: Manifest](x: Exp[E]):Exp[E] = reflectMutable(SteMakeMutable[E](x))
   def steUpdate      [E <: Entry: Manifest](x: Exp[E], i: Int, v: Exp[Any]): Exp[Unit] = reflectWrite(x)(SteUpdate[E](x, i, v))
   def steIncrease    [E <: Entry: Manifest](x: Exp[E], i: Int, v: Exp[Any]): Exp[Unit] = reflectWrite(x)(SteIncrease[E](x, i, v))
   def steDecrease    [E <: Entry: Manifest](x: Exp[E], i: Int, v: Exp[Any]): Exp[Unit] = reflectWrite(x)(SteDecrease[E](x, i, v))
   def steGet         [E <: Entry: Manifest](x: Exp[E], i: Int): Exp[Any] = SteGet[E](x, i)
+  def steCopy        [E <: Entry: Manifest](x: Exp[E]): Exp[E] = reflectWrite(x)(SteCopy[E](x))
+  def steLogUpdate   [E <: Entry: Manifest](s: Exp[Store[E]], x: Exp[E], y: Exp[E]): Exp[Unit] = reflectWrite(x)(SteLogUpdate[E](s, x, y))
 
   //////////////
   // mirroring
@@ -117,6 +121,8 @@ trait ScalaGenSEntry extends ScalaGenBase with dbtoptimizer.ToasterBoosterScalaC
     //   case Some(fld: String) => emitValDef(sym, fld)
     //   case _ => emitValDef(sym, quote(x) + "._" + i)
     // }
+    case SteCopy(x) => emitValDef(sym, quote(x) + ".copy")
+    case SteLogUpdate(s, x, y) => emitValDef(sym, quote(s) + ".logUpdate(" + quote(x) + ", " + quote(y) +")")
     case _ => super.emitNode(sym, rhs)
   }
 }
@@ -511,6 +517,7 @@ trait ScalaGenStore extends ScalaGenBase with ScalaGenSEntry
                                          with GenericGenStore {
   val IR: StoreExp with ExtendedExpressions with Effects
   import IR._
+  import ddbt.codegen.ScalaGen.STORE_WATCHED
 
   override def emitNode(sym: Sym[Any], rhs: Def[Any]) = rhs match {
     case StNewStore(mE) => {
@@ -633,6 +640,9 @@ trait ScalaGenStore extends ScalaGenBase with ScalaGenSEntry
       out.println("  def copy = " + clsName + "(" + 
         argTypes.zipWithIndex.map { case (_, i) => "_%d".format(i + 1) }
         .mkString(", ") + ")")
+      out.println("  def elements = Array[Any](" +
+        argTypes.zipWithIndex.map { case (_, i) => "_%d".format(i + 1) }
+        .mkString(", ") + ").asInstanceOf[Array[AnyRef]]")
       //val l="_"+argTypes.size
       //out.println("  override def zero = "+l+" == "+zeroValue(argTypes.last))
       //out.println("  override def merge(e0:Entry) { val e=e0.asInstanceOf["+clsName+"]; "+l+" "+(argTypes.last match { case "java.util.Date" => "= new Date("+l+".getTime + e."+l+".getTime)" case _ => "+= e."+l })+" }")
@@ -683,7 +693,11 @@ trait ScalaGenStore extends ScalaGenBase with ScalaGenSEntry
     }
     val cName = quote(c, true)
     val entTp = storeEntryType(c)
-    out.println("val "+cName+" = new Store["+entTp+"]("+idxArr.size+",Array[EntryIdx["+entTp+"]]("+(0 until idxArr.size).map(i=>entTp+"_Idx"+i).mkString(",")+"))")
+
+    val watched = c.attributes.get(STORE_WATCHED).asInstanceOf[Option[Boolean]].getOrElse(false)
+    val storeType = (if (watched) "StoreWrapper" else "Store")
+
+    out.println("val "+cName+" = new " + storeType + "["+entTp+"]("+idxArr.size+",Array[EntryIdx["+entTp+"]]("+(0 until idxArr.size).map(i=>entTp+"_Idx"+i).mkString(",")+"))")
     idxArr.zipWithIndex.foreach { case ((idxType, idxLoc, idxUniq, idxSliceIdx), i) => idxType match {
       case IList => out.println("%s.index(%d,IList,%s)".format(cName, i, idxUniq))
       case IHash => out.println("%s.index(%d,IHash,%s)".format(cName, i, idxUniq))

--- a/lms/tpcc/lmsgen/TpccBench.scala
+++ b/lms/tpcc/lmsgen/TpccBench.scala
@@ -628,6 +628,7 @@ class stockLevelTx(x0: Store[SEntry3_III], x1: Store[SEntry8_IIIIIAFS], x2: Stor
       if(_1 == e._1 && _2 == e._2) 0 else 1
     }
     def copy = SEntry11_IISSSSSSFDI(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11)
+    def elements = Array[Any](_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11).asInstanceOf[Array[AnyRef]]
   }
   case class SEntry8_IIIIIAFS(var _1:Int = 0, var _2:Int = 0, var _3:Int = 0, var _4:Int = 0, var _5:Int = 0, var _6:java.util.Date = null, var _7:Float = 0f, var _8:java.lang.String = null) extends Entry(8) {
     def hash(i: Int):Int = {
@@ -698,6 +699,7 @@ class stockLevelTx(x0: Store[SEntry3_III], x1: Store[SEntry8_IIIIIAFS], x2: Stor
       } else { 0 }
     }
     def copy = SEntry8_IIIIIAFS(_1, _2, _3, _4, _5, _6, _7, _8)
+    def elements = Array[Any](_1, _2, _3, _4, _5, _6, _7, _8).asInstanceOf[Array[AnyRef]]
   }
   case class SEntry8_IIIIAIIB(var _1:Int = 0, var _2:Int = 0, var _3:Int = 0, var _4:Int = 0, var _5:java.util.Date = null, var _6:Int = 0, var _7:Int = 0, var _8:Boolean = false) extends Entry(8) {
     def hash(i: Int):Int = {
@@ -782,6 +784,7 @@ class stockLevelTx(x0: Store[SEntry3_III], x1: Store[SEntry8_IIIIIAFS], x2: Stor
       } else { 0 }
     }
     def copy = SEntry8_IIIIAIIB(_1, _2, _3, _4, _5, _6, _7, _8)
+    def elements = Array[Any](_1, _2, _3, _4, _5, _6, _7, _8).asInstanceOf[Array[AnyRef]]
   }
   case class SEntry17_IIISSSSSSSSSSIIIS(var _1:Int = 0, var _2:Int = 0, var _3:Int = 0, var _4:java.lang.String = null, var _5:java.lang.String = null, var _6:java.lang.String = null, var _7:java.lang.String = null, var _8:java.lang.String = null, var _9:java.lang.String = null, var _10:java.lang.String = null, var _11:java.lang.String = null, var _12:java.lang.String = null, var _13:java.lang.String = null, var _14:Int = 0, var _15:Int = 0, var _16:Int = 0, var _17:java.lang.String = null) extends Entry(17) {
     def hash(i: Int):Int = {
@@ -793,6 +796,7 @@ class stockLevelTx(x0: Store[SEntry3_III], x1: Store[SEntry8_IIIIIAFS], x2: Stor
       if(_1 == e._1 && _2 == e._2) 0 else 1
     }
     def copy = SEntry17_IIISSSSSSSSSSIIIS(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17)
+    def elements = Array[Any](_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17).asInstanceOf[Array[AnyRef]]
   }
   case class SEntry21_IIISSSSSSSSSASFFFFIIS(var _1:Int = 0, var _2:Int = 0, var _3:Int = 0, var _4:java.lang.String = null, var _5:java.lang.String = null, var _6:java.lang.String = null, var _7:java.lang.String = null, var _8:java.lang.String = null, var _9:java.lang.String = null, var _10:java.lang.String = null, var _11:java.lang.String = null, var _12:java.lang.String = null, var _13:java.util.Date = null, var _14:java.lang.String = null, var _15:Float = 0f, var _16:Float = 0f, var _17:Float = 0f, var _18:Float = 0f, var _19:Int = 0, var _20:Int = 0, var _21:java.lang.String = null) extends Entry(21) {
     def hash(i: Int):Int = {
@@ -838,6 +842,7 @@ class stockLevelTx(x0: Store[SEntry3_III], x1: Store[SEntry8_IIIIIAFS], x2: Stor
       } else { 0 }
     }
     def copy = SEntry21_IIISSSSSSSSSASFFFFIIS(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21)
+    def elements = Array[Any](_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21).asInstanceOf[Array[AnyRef]]
   }
   case class SEntry10_IIIIIIAIFS(var _1:Int = 0, var _2:Int = 0, var _3:Int = 0, var _4:Int = 0, var _5:Int = 0, var _6:Int = 0, var _7:java.util.Date = null, var _8:Int = 0, var _9:Float = 0f, var _10:java.lang.String = null) extends Entry(10) {
     def hash(i: Int):Int = {
@@ -878,6 +883,7 @@ class stockLevelTx(x0: Store[SEntry3_III], x1: Store[SEntry8_IIIIIAFS], x2: Stor
       } else { 0 }
     }
     def copy = SEntry10_IIIIIIAIFS(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10)
+    def elements = Array[Any](_1, _2, _3, _4, _5, _6, _7, _8, _9, _10).asInstanceOf[Array[AnyRef]]
   }
   case class SEntry3_III(var _1:Int = 0, var _2:Int = 0, var _3:Int = 0) extends Entry(3) {
     def hash(i: Int):Int = {
@@ -928,6 +934,7 @@ class stockLevelTx(x0: Store[SEntry3_III], x1: Store[SEntry8_IIIIIAFS], x2: Stor
       } else { 0 }
     }
     def copy = SEntry3_III(_1, _2, _3)
+    def elements = Array[Any](_1, _2, _3).asInstanceOf[Array[AnyRef]]
   }
   case class SEntry5_IISFS(var _1:Int = 0, var _2:Int = 0, var _3:java.lang.String = null, var _4:Float = 0f, var _5:java.lang.String = null) extends Entry(5) {
     def hash(i: Int):Int = {
@@ -939,6 +946,7 @@ class stockLevelTx(x0: Store[SEntry3_III], x1: Store[SEntry8_IIIIIAFS], x2: Stor
       if(_1 == e._1) 0 else 1
     }
     def copy = SEntry5_IISFS(_1, _2, _3, _4, _5)
+    def elements = Array[Any](_1, _2, _3, _4, _5).asInstanceOf[Array[AnyRef]]
   }
   case class SEntry9_ISSSSSSFD(var _1:Int = 0, var _2:java.lang.String = null, var _3:java.lang.String = null, var _4:java.lang.String = null, var _5:java.lang.String = null, var _6:java.lang.String = null, var _7:java.lang.String = null, var _8:Float = 0f, var _9:Double = 0D) extends Entry(9) {
     def hash(i: Int):Int = {
@@ -950,6 +958,7 @@ class stockLevelTx(x0: Store[SEntry3_III], x1: Store[SEntry8_IIIIIAFS], x2: Stor
       if(_1 == e._1) 0 else 1
     }
     def copy = SEntry9_ISSSSSSFD(_1, _2, _3, _4, _5, _6, _7, _8, _9)
+    def elements = Array[Any](_1, _2, _3, _4, _5, _6, _7, _8, _9).asInstanceOf[Array[AnyRef]]
   }
   class EfficientExecutor {
     val x0 = new Store[SEntry3_III](2)

--- a/src/Compiler.scala
+++ b/src/Compiler.scala
@@ -42,6 +42,7 @@ object Compiler {
   var libs : List[String] = Nil  // runtime libraries (defaults to lib/ddbt.jar for scala)
   var ni   : Boolean = false     // non-incremental query evaluation (implies depth=0)
   var inl  : Int = 0             // inlining level, in range [0-10]
+  var watch : Boolean = false   // stream of updates on result map
   // Execution
   var exec    : Boolean = false  // compile and execute immediately
   var exec_dir: String  = null   // execution classpath
@@ -119,6 +120,7 @@ object Compiler {
                                       else try { 
                                         math.min(10, math.max(0, s.toInt)) 
                                       } catch { case _: Throwable => 0 })
+        case "-w" => watch = true;
         case "-ni" => ni = true; depth = 0; flags = Nil
         case "-x" => exec = true
         case "-xd" => eat(s => exec_dir = s)
@@ -217,7 +219,7 @@ object Compiler {
       case LANG_AKKA => new AkkaGen(name)
       case LANG_LMS => new LMSCppGen(name)
       case LANG_CPP_LMS => new LMSCppGen(name)
-      case LANG_SCALA_LMS => new LMSScalaGen(name)
+      case LANG_SCALA_LMS => new LMSScalaGen(name, watch)
       case LANG_SPARK_LMS => new LMSSparkGen(name)
       case _ => error("Code generation for " + lang + " is not supported", true)
     }

--- a/src/lib/IQuery.scala
+++ b/src/lib/IQuery.scala
@@ -1,0 +1,7 @@
+package ddbt.lib
+
+import ddbt.lib.Messages.StreamEvent
+
+trait IQuery {
+  def handleEvent(e: StreamEvent): Any
+}

--- a/src/lib/Messages.scala
+++ b/src/lib/Messages.scala
@@ -26,6 +26,7 @@ object Messages {
   // Command messages
   case class StreamInit(timeout: Long = 0L) extends StreamEvent // timeout in ms
   case class GetSnapshot(view: List[Int]) extends StreamEvent // request a snapshot of some maps
+  case class GetStream(view: Int) extends StreamEvent // get stream of update
   /** System state (returned with snapshot) */
   case class StreamStat(ns: Long, count: Long, skip: Long) { 
     override def toString = { 

--- a/src/lib/store/Entry.java
+++ b/src/lib/store/Entry.java
@@ -12,6 +12,7 @@ public abstract class Entry {
   final Object[] data;
   public Entry(int n) { data=new Object[n]; }
   abstract public Entry copy(); // returns a copy of the entry, for B-Trees only
+  abstract public Object[] elements();
   //abstract public boolean zero(); // the tuple can safely be deleted from the map
   //abstract public void merge(Entry e); // combine e in this (some kine of aggregation)
 


### PR DESCRIPTION
For SquallToast, there are two necessary changes:
1. Output map / output value to produce a stream of update tuples when its values change
2. Invoke event handlers directly instead of via Akka as SquallToast use DBToaster in single thread and the latency of asynchronous messaging is not necessary. 

So the main changes include:
- Add a `-w` flag in the Compiler option to turn on and off the feature. This option must be used together with `-l scala` option because the change is only applied to LMSScala
- When the feature turned on:
  - Output Map will use type `StoreWrapper` instead of `Store`. Output value will be `ValueWrapper` instead of numeric type. 
  - `getStream` is added to the event handler
  - 2 Query classes are generated. One implements the `IQuery` interface and one extends from it and implements `Actor` interface. 
  - In the generated code, logging method is invoked when the output is updated.  
