### PR TITLE
Print tuples when compiled with DBT_TRACE or DBT_TRACE_ALL

### DIFF
--- a/ddbtoaster/srccpp/old_driver/program_base.hpp
+++ b/ddbtoaster/srccpp/old_driver/program_base.hpp
@@ -169,7 +169,8 @@ public:
 
 protected:
 	void set_log_count_every(unsigned int _log_count_every);
-	
+
+    void print_tuple(const event_t &evt);
     void process_event(const event_t& evt, const bool process_table);
     void process_stream_event(const event_t& evt);
 	void process_remaining_events();

--- a/ddbtoaster/srccpp/old_driver/standard_adaptors.cpp
+++ b/ddbtoaster/srccpp/old_driver/standard_adaptors.cpp
@@ -15,22 +15,25 @@ namespace adaptors {
 ******************************************************************************/
 
 csv_adaptor::csv_adaptor(relation_id_t _id) 
-		: id(_id), type(insert_tuple), schema_size(0), delimiter(",") 
+		: type(insert_tuple), delimiter(",")
 {
 	schema = std::string();
+    id = _id;
 }
 
 csv_adaptor::csv_adaptor(relation_id_t _id, std::string sch)
-		: id(_id), type(insert_tuple), schema_size(0), delimiter(",")
+		: type(insert_tuple), delimiter(",")
 {
+    id = _id;
 	schema = std::string(sch);
 	validate_schema();
 }
 
 csv_adaptor::csv_adaptor(relation_id_t i, int num_params,
 						const std::pair<std::string,std::string> params[])
-		: id(i), type(insert_tuple), schema_size(0), delimiter(",")
+		: type(insert_tuple), delimiter(",")
 {
+    id = i;
 	parse_params(num_params,params);
 	validate_schema();
 }

--- a/ddbtoaster/srccpp/old_driver/standard_adaptors.hpp
+++ b/ddbtoaster/srccpp/old_driver/standard_adaptors.hpp
@@ -15,10 +15,7 @@ namespace dbtoaster {
 
     struct csv_adaptor : public stream_adaptor
     {
-      relation_id_t id;
       event_type type;
-      string schema;
-      size_t schema_size;
       std::string delimiter;
       
       std::shared_ptr<event_t> saved_event;

--- a/ddbtoaster/srccpp/old_driver/streams.hpp
+++ b/ddbtoaster/srccpp/old_driver/streams.hpp
@@ -22,7 +22,14 @@ namespace streams {
 
 struct stream_adaptor
 {
-    stream_adaptor() {}
+    relation_id_t id;
+    string schema;
+    size_t schema_size;
+
+    stream_adaptor() {
+        schema = "";
+        schema_size = 0;
+    }
 
     virtual void read_adaptor_events(char* data, std::shared_ptr<std::list<event_t> > eventList, std::shared_ptr<std::list<event_t> > eventQue) = 0;
 };


### PR DESCRIPTION
Compiling with flag DBT_TRACE was broken because tuples were not being parsed
before being printed. This modification adds a method called print_tuple that
parses the current tuple and prints it to stdout. Tuples are only printed to the
standard output when compiled with DBT_TRACE or DBT_TRACE_ALL.

Signed-off-by: Edson Lucas <edson.lucas@uni-passau.de>